### PR TITLE
Update 2.6.0 for Linux and Windows

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -27,14 +27,13 @@ declare(strict_types=1);
 return [
 	'Nextcloud' => [
 		'linux' => [
-			'version' => '2.3.2',
-			'versionstring' => 'Nextcloud Client 2.3.2',
+			'version' => '2.6.0',
+			'versionstring' => 'Nextcloud Client 2.6.0',
 			'web' => 'https://nextcloud.com/install/?pk_campaign=clientupdate#install-clients',
 		],
 		'win32' => [
-			'version' => '2.3.2.1',
-			'versionstring' => 'Nextcloud Client 2.3.2 (build 1)',
-			'downloadUrl' => 'https://download.nextcloud.com/desktop/releases/Windows/Nextcloud-2.3.2.1-setup.exe',
+			'version' => '2.6.0',
+			'versionstring' => 'Nextcloud Client 2.6.0',
 			'web' => 'https://nextcloud.com/install/?pk_campaign=clientupdate#install-clients',
 		],
 		'macos' => [


### PR DESCRIPTION
Announce the 2.6.0 client updates for Linux and Windows.

Mac is under consideration, work in progress because the client only shows "update available, install via your system's update tool" and doesn't open the update link.


Signed-off-by: Michael Schuster <michael@schuster.ms>