### PR TITLE
Update 2.6.1 for Linux and Windows

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -27,13 +27,13 @@ declare(strict_types=1);
 return [
 	'Nextcloud' => [
 		'linux' => [
-			'version' => '2.6.0',
-			'versionstring' => 'Nextcloud Client 2.6.0',
+			'version' => '2.6.1',
+			'versionstring' => 'Nextcloud Client 2.6.1',
 			'web' => 'https://nextcloud.com/install/?pk_campaign=clientupdate#install-clients',
 		],
 		'win32' => [
-			'version' => '2.6.0',
-			'versionstring' => 'Nextcloud Client 2.6.0',
+			'version' => '2.6.1',
+			'versionstring' => 'Nextcloud Client 2.6.1',
 			'web' => 'https://nextcloud.com/install/?pk_campaign=clientupdate#install-clients',
 		],
 		'macos' => [


### PR DESCRIPTION
Announce the 2.6.1 client updates for Linux and Windows.

Mac will follow soon, work in progress because the client only shows "update available, install via your system's update tool" and doesn't open the update link.