### PR TITLE
Update 2.6.2 for macOS - fix manual download link

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -41,6 +41,8 @@ return [
 			'versionstring' => 'Nextcloud Client 2.6.2',
 			'downloadUrl' => 'https://download.nextcloud.com/desktop/releases/Mac/Updates/Nextcloud-2.6.2.20191224.pkg.tbz',
 			'signature' => 'MC0CFQCOID+LO2tm/XrC21cX+jRZ+QQxSAIUeCR3OdQSc5vRBau3uEBIazpcmO0=',
+
+			'web' => 'https://download.nextcloud.com/desktop/releases/Mac/Installer/Nextcloud-2.6.2.20191224.pkg',
 		],
 	],
 ];


### PR DESCRIPTION
Allow manual download for macOS until we can fix the auto updater.