### PR TITLE
Throttle down desktop release

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
  */
 return [
 	'Nextcloud' => [
+		'release' => '2019-02-24 17:05',
 		'linux' => [
 			'version' => '2.6.2',
 			'versionstring' => 'Nextcloud Client 2.6.2',

--- a/index.php
+++ b/index.php
@@ -83,6 +83,7 @@ $oem = isset($_GET['oem']) ? (string)$_GET['oem'] : null;
 $platform = isset($_GET['platform']) ? (string)$_GET['platform'] : null;
 $version = isset($_GET['version']) ? (string)$_GET['version'] : null;
 $isSparkle = isset($_GET['sparkle']) ? true : false;
+$updateSegment = isset($_GET['updatesegment']) ? (int)$_GET['updatesegment'] : -1;
 
 if($oem === null || $platform === null || $version === null) {
 	die();
@@ -96,6 +97,7 @@ $response = new \ClientUpdateServer\Response(
 	$platform,
 	$version,
 	$isSparkle,
+	$updateSegment,
 	$config
 );
 echo $response->buildResponse();

--- a/src/Response.php
+++ b/src/Response.php
@@ -31,17 +31,11 @@ class Response {
 	private $version;
 	/** @var bool */
 	private $isSparkle;
+	/** @var int */
+	private $updateSegment;
 	/** @var array */
 	private $config;
 
-	/**
-	 * @param string $oem
-	 * @param string $platform
-	 * @param string $version
-	 * @param bool $isSparkle
-	 * @param int $updatesegment
-	 * @param array $config
-	 */
 	public function __construct(string $oem,
 								string $platform,
 								string $version,
@@ -99,7 +93,7 @@ class Response {
 		$chunks = floor($this->updateSegment / 10);
 		$throttleDate->sub(new \DateInterval('PT' . (12 * $chunks) . 'H'));
 
-		if ($throttleDate <= $releaseDate) {
+		if ($throttleDate >= $releaseDate) {
 			$values = $this->config[$this->oem][$this->platform];
 			if(version_compare($this->version, $values['version']) === -1) {
 				return $values;

--- a/tests/unit/ResponseTest.php
+++ b/tests/unit/ResponseTest.php
@@ -23,10 +23,7 @@ namespace Tests;
 
 class ResponseTest extends \PHPUnit_Framework_TestCase {
 
-	/**
-	 * @return array
-	 */
-	public function updateDataProvider() {
+	public function updateDataProvider(): array {
 		$config = [
 			'nextcloud' => [
 				'release' => '2019-02-24 17:05',
@@ -48,7 +45,36 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
 				],
 			]
 		];
+
+		$configThrottle = $config;
+		$configThrottle['nextcloud']['release'] = (new \DateTime())->sub(new \DateInterval('PT6H'))->format('Y-m-d H:m');
+
 		return [
+			// Update segment is already allowed
+			[
+				'nextcloud',
+				'win32',
+				'1.9.0',
+				false,
+				5,
+				$configThrottle,
+				'<?xml version="1.0"?>
+<owncloudclient><version>2.2.2.6192</version><versionstring>Nextcloud Client 2.2.2 (build 6192)</versionstring><downloadUrl>https://download.nextcloud.com/desktop/stable/ownCloud-2.2.2.6192-setup.exe</downloadUrl></owncloudclient>
+'
+			],
+			// Update segment is not yet allowed
+			[
+				'nextcloud',
+				'win32',
+				'1.9.0',
+				false,
+				95,
+				$configThrottle,
+				'<?xml version="1.0"?>
+<owncloudclient/>
+'
+			],
+
 			// Updates for client available
 			[
 				'nextcloud',

--- a/tests/unit/ResponseTest.php
+++ b/tests/unit/ResponseTest.php
@@ -29,6 +29,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
 	public function updateDataProvider() {
 		$config = [
 			'nextcloud' => [
+				'release' => '2019-02-24 17:05',
 				'linux' => [
 					'version' => '2.2.2',
 					'versionstring' => 'Nextcloud Client 2.2.2',
@@ -54,6 +55,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
 				'win32',
 				'1.9.0',
 				false,
+				-1,
 				$config,
 				'<?xml version="1.0"?>
 <owncloudclient><version>2.2.2.6192</version><versionstring>Nextcloud Client 2.2.2 (build 6192)</versionstring><downloadUrl>https://download.nextcloud.com/desktop/stable/ownCloud-2.2.2.6192-setup.exe</downloadUrl></owncloudclient>
@@ -64,6 +66,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
 				'win32',
 				'1.9.0',
 				true,
+				-1,
 				$config,
 				'<?xml version="1.0"?>
 <owncloudclient><version>2.2.2.6192</version><versionstring>Nextcloud Client 2.2.2 (build 6192)</versionstring><downloadUrl>https://download.nextcloud.com/desktop/stable/ownCloud-2.2.2.6192-setup.exe</downloadUrl></owncloudclient>
@@ -74,6 +77,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
 				'linux',
 				'1.9.0',
 				false,
+				-1,
 				$config,
 				'<?xml version="1.0"?>
 <owncloudclient><version>2.2.2</version><versionstring>Nextcloud Client 2.2.2</versionstring><web>https://nextcloud.com/install/#install-clients</web></owncloudclient>
@@ -84,6 +88,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
 				'macos',
 				'1.9.0',
 				false,
+				-1,
 				$config,
 				'<?xml version="1.0"?>
 <owncloudclient><version>2.2.2.3472</version><versionstring>Nextcloud Client 2.2.2 (build 3472)</versionstring><downloadUrl>https://download.owncloud.com/desktop/stable/ownCloud-2.2.2.3472.pkg.tbz</downloadUrl><signature>MC0CFQDmXR6biDmNVW7TvMh0bfPPTzCvtwIUCzASgpzYdi4lltOnwbFCeQwgDjY=</signature></owncloudclient>
@@ -94,6 +99,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
 				'macos',
 				'1.9.0',
 				true,
+				-1,
 				$config,
 				'<?xml version="1.0" encoding="utf-8"?>
 <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -114,6 +120,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
 				'macos',
 				'1.9.0',
 				false,
+				-1,
 				$config,
 				'<?xml version="1.0"?>
 <owncloudclient/>
@@ -124,6 +131,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
 				'ramdomOs',
 				'1.9.0',
 				false,
+				-1,
 				$config,
 				'<?xml version="1.0"?>
 <owncloudclient/>
@@ -135,6 +143,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
 				'win32',
 				'2.2.2.6192',
 				false,
+				-1,
 				$config,
 				'<?xml version="1.0"?>
 <owncloudclient/>
@@ -145,6 +154,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
 				'win32',
 				'2.2.6192',
 				true,
+				-1,
 				$config,
 				'<?xml version="1.0"?>
 <owncloudclient/>
@@ -155,6 +165,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
 				'linux',
 				'2.2.2',
 				false,
+				-1,
 				$config,
 				'<?xml version="1.0"?>
 <owncloudclient/>
@@ -165,6 +176,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
 				'macos',
 				'2.2.2.3472',
 				false,
+				-1,
 				$config,
 				'<?xml version="1.0"?>
 <owncloudclient/>
@@ -175,6 +187,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
 				'macos',
 				'2.2.2.3472',
 				true,
+				-1,
 				$config,
 				'<?xml version="1.0" encoding="utf-8"?>
 <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -190,6 +203,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
 				'win32',
 				'2.3',
 				false,
+				-1,
 				$config,
 				'<?xml version="1.0"?>
 <owncloudclient/>
@@ -200,6 +214,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
 				'win32',
 				'2.3',
 				true,
+				-1,
 				$config,
 				'<?xml version="1.0"?>
 <owncloudclient/>
@@ -210,6 +225,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
 				'linux',
 				'2.3',
 				false,
+				-1,
 				$config,
 				'<?xml version="1.0"?>
 <owncloudclient/>
@@ -220,6 +236,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
 				'macos',
 				'2.3',
 				false,
+				-1,
 				$config,
 				'<?xml version="1.0"?>
 <owncloudclient/>
@@ -230,6 +247,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
 				'macos',
 				'2.3',
 				true,
+				-1,
 				$config,
 				'<?xml version="1.0" encoding="utf-8"?>
 <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -249,6 +267,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
 	 * @param string $platform
 	 * @param string $version
 	 * @param bool $isSparkle
+	 * @param int $updateSegment
 	 * @param array $config
 	 * @param string $expected
 	 */
@@ -256,10 +275,11 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
 									  string $platform,
 									  string $version,
 									  bool $isSparkle,
+									  int $updateSegment,
 									  array $config,
 									  string $expected) {
 		$response = $this->getMockBuilder('\ClientUpdateServer\Response')
-			->setConstructorArgs([$oem, $platform, $version, $isSparkle, $config])
+			->setConstructorArgs([$oem, $platform, $version, $isSparkle, $updateSegment, $config])
 			->setMethods(['getCurrentTimeStamp'])
 			->getMock();
 		$response


### PR DESCRIPTION
New approach:
- if there is updateSegment (starting with 2.6.4) use it
- if there is only release date, randomly throttle

Both will increase 10% after each 12h 