### PR TITLE
Update 2.6.2: Fix release date (Dec 2019)

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -26,7 +26,7 @@ declare(strict_types=1);
  */
 return [
 	'Nextcloud' => [
-		'release' => '2019-02-24 17:05',
+		'release' => '2019-12-24 17:05',
 		'linux' => [
 			'version' => '2.6.2',
 			'versionstring' => 'Nextcloud Client 2.6.2',


### PR DESCRIPTION
@tobiasKaminsky Copy paste typo thingy because of this February's change I guess? ;-)

Or is this intended to begin the rollout tomorrow? (Well what a date-coincidence then ^^)