### PR TITLE
Distribute 3.1.1 releases

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -47,6 +47,17 @@ if (version_compare($version, '3.0.3') < 0) {
 	$mac_url = $url;
 }
 
+if (version_compare($version, '3.1.0') < 0) {
+    $windows_suffix = '-setup.exe';
+} else {
+    if ($buildArch === 'i386') {
+        $windows_suffix = '-x86.msi';
+    } else {
+        $windows_suffix = '-x64.msi';
+    }
+}
+
+
 /**
  * Associative array of OEM => OS => version
  */
@@ -62,7 +73,7 @@ return [
 		'win32' => [
 			'version' => $ver,
 			'versionstring' => $ver_str,
-			'downloadurl' => $windows_url . 'Nextcloud-' . $ver . '-setup.exe',
+			'downloadurl' => $windows_url . 'Nextcloud-' . $ver . $windows_suffix,
 			'web' => 'https://nextcloud.com/install/?pk_campaign=clientupdate#install-clients',
 		],
 		'macos' => [

--- a/config/config.php
+++ b/config/config.php
@@ -21,11 +21,11 @@
 
 declare(strict_types=1);
 
-$rel = '2020-10-30 12:00';
-$ver = '3.0.3';
+$rel = '2020-12-23 12:00';
+$ver = '3.1.1';
 
-$old_rel = '2020-09-28 18:00';
-$old_ver = '3.0.2';
+$old_rel = '2020-10-30 12:00';
+$old_ver = '3.0.3';
 
 // in 90% of the cases ship the old version. Otherwise ship the current version.
 if (rand(0, 9) !== 2) {

--- a/index.php
+++ b/index.php
@@ -81,6 +81,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' &&
 // Read parameters
 $oem = isset($_GET['oem']) ? (string)$_GET['oem'] : null;
 $platform = isset($_GET['platform']) ? (string)$_GET['platform'] : null;
+$buildArch = isset($_GET['buildArch']) ? (string)$_GET['buildArch'] : "x86_64";
+$currentArch = isset($_GET['currentArch']) ? (string)$_GET['currentArch'] : "x86_64";
 $version = isset($_GET['version']) ? (string)$_GET['version'] : null;
 $isSparkle = isset($_GET['sparkle']) ? true : false;
 $updateSegment = isset($_GET['updatesegment']) ? (int)$_GET['updatesegment'] : -1;


### PR DESCRIPTION
This pull request does several things:
 * it adds support for the architecture query parameters that the client now sends since 3.1.0;
 * it proposes one of the msi files if the version is 3.1.0 or above (and picks the right file based on the build architecture of the current client);
 * it updates the latest version proposed to be 3.1.1