### PR TITLE
Remove the aggressive throttling

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -24,15 +24,6 @@ declare(strict_types=1);
 $rel = '2020-12-23 12:00';
 $ver = '3.1.1';
 
-$old_rel = '2020-10-30 12:00';
-$old_ver = '3.0.3';
-
-// in 90% of the cases ship the old version. Otherwise ship the current version.
-if (rand(0, 9) !== 2) {
-	$rel = $old_rel;
-	$ver = $old_ver;
-}
-
 $ver_str = 'Nextcloud Client ' . $ver;
 
 if (version_compare($version, '3.0.3') < 0) {


### PR DESCRIPTION
Since nowadays most clients in the wild are 3.0.3 or above we should
likely remove that random roll of wrongly claiming the client is up to
date and rely on the update segment only again.

I'd expect this would fix nextcloud/desktop#2809 we're getting too many
of those "why didn't I get the update yet" and that's the only
explanation I have so far.

Signed-off-by: Kevin Ottens <kevin.ottens@nextcloud.com>