### PR TITLE
fix upgrade of old desktop versions only able to use .exe updater

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -40,6 +40,7 @@ if (version_compare($version, '3.0.3') < 0) {
 
 if (version_compare($version, '3.1.0') < 0) {
     $windows_suffix = '-setup.exe';
+    $ver = '3.1.3';
 } else {
     if ($buildArch === 'i386') {
         $windows_suffix = '-x86.msi';


### PR DESCRIPTION
for old versions of desktop client use the highest version with .exe
installer to update in two steps:

1) update 3.0.2 to 3.1.3
2) update 3.1.3 to 3.2.2

should avoid having clients trying to download inexisting files from
nextcloud server

Signed-off-by: Matthieu Gallien <matthieu.gallien@nextcloud.com>