### PR TITLE
Add beta/stable channel support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,23 +10,47 @@ If the default `config.php` doesn't hold update information for this OEM, the co
 
 ```json
 {
-  "release": "2022-01-27 14:31",
-  "linux": {
-    "version": "2.3.2",
-    "versionstring": "Nextcloud Client 2.3.2",
-    "web": "https://nextcloud.com/install/?pk_campaign=clientupdate#install-clients"
+  "stable": {
+    "release": "2022-01-01 13:00",
+    "linux": {
+      "version": "2.3.2",
+      "versionstring": "Nextcloud Client 2.3.2",
+      "downloadUrl": "https://download.nextcloud.com/desktop/releases/Linux/Nextcloud-2.3.2.1-setup.AppImage",
+      "web": "https://nextcloud.com/install/?pk_campaign=clientupdate#install-clients"
+    },
+    "win32": {
+      "version": "2.3.2.1",
+      "versionstring": "Nextcloud Client 2.3.2 (build 1)",
+      "downloadUrl": "https://download.nextcloud.com/desktop/releases/Windows/Nextcloud-2.3.2.1-setup.exe",
+      "web": "https://nextcloud.com/install/?pk_campaign=clientupdate#install-clients"
+    },
+    "macos": {
+      "version": "2.2.4.1",
+      "versionstring": "Nextcloud Client 2.2.4 (build 1)",
+      "downloadUrl": "https://download.nextcloud.com/desktop/releases/Mac/Updates/Nextcloud-2.2.4.1.pkg.tbz",
+      "signature": "MCwCFGC3X/fejC/y/3T2X+c8ldDk7pJGAhQoR8v6vtvvV57nIcMNePA+jNRYcw=="
+    }
   },
-  "win32": {
-    "version": "2.3.2.1",
-    "versionstring": "Nextcloud Client 2.3.2 (build 1)",
-    "downloadUrl": "https://download.nextcloud.com/desktop/releases/Windows/Nextcloud-2.3.2.1-setup.exe",
-    "web": "https://nextcloud.com/install/?pk_campaign=clientupdate#install-clients"
-  },
-  "macos": {
-    "version": "2.2.4.1",
-    "versionstring": "Nextcloud Client 2.2.4 (build 1)",
-    "downloadUrl": "https://download.nextcloud.com/desktop/releases/Mac/Updates/Nextcloud-2.2.4.1.pkg.tbz",
-    "signature": "MCwCFGC3X/fejC/y/3T2X+c8ldDk7pJGAhQoR8v6vtvvV57nIcMNePA+jNRYcw=="
+  "beta": {
+    "release": "2022-01-27 14:31",
+    "linux": {
+      "version": "3.5.6-rc1",
+      "versionstring": "Nextcloud Client 3.5.6 RC1",
+      "downloadUrl": "https://download.nextcloud.com/desktop/releases/Linux/Nextcloud-3.5.6-rc1-setup.AppImage",
+      "web": "https://nextcloud.com/install/?pk_campaign=clientupdate#install-clients"
+    },
+    "win32": {
+      "version": "3.5.6-rc1",
+      "versionstring": "Nextcloud Client 3.5.6 RC1",
+      "downloadUrl": "https://download.nextcloud.com/desktop/releases/Windows/Nextcloud-3.5.6-rc1-setup.exe",
+      "web": "https://nextcloud.com/install/?pk_campaign=clientupdate#install-clients"
+    },
+    "macos": {
+      "version": "3.5.6-rc1",
+      "versionstring": "Nextcloud Client 3.5.6 RC1",
+      "downloadUrl": "https://download.nextcloud.com/desktop/releases/Mac/Updates/Nextcloud-3.5.6-rc1-pkg.tbz",
+      "signature": "MCwCFGC3X/fejC/y/3T2X+c8ldDk7pJGAhQoR8v6vtvvV57nIcMNePA+jNRYcw=="
+    }
   }
 }
 ```

--- a/config/config.php
+++ b/config/config.php
@@ -21,31 +21,40 @@
 
 declare(strict_types=1);
 
-$rel = '2022-03-18 16:00';
-$ver = '3.4.4';
+$stableReleaseDate = '2022-03-18 16:00';
+$stableVersion = '3.4.4';
 
-$ver_str = 'Nextcloud Client ' . $ver;
+$betaReleaseDate = '2022-03-18 18:30';
+$betaVersion = '3.5.0-rc1';
+
+$stableVersionString = 'Nextcloud Client ' . $stableVersion;
+$betaVersionString = 'Nextcloud Client ' . $betaVersion;
 
 if (version_compare($version, '3.0.3') < 0) {
 	$url = 'https://download.nextcloud.com/desktop/releases/';
-	$linux_url = $url . 'Linux/';
-	$windows_url = $url . 'Windows/';
-	$mac_url = $url . 'Mac/Installer/';
+	$stable_linux_url = $url . 'Linux/';
+	$stable_windows_url = $url . 'Windows/';
+	$stable_mac_url = $url . 'Mac/Installer/';
 } else {
-	$url = 'https://github.com/nextcloud/desktop/releases/download/v' . $ver . '/';
-	$linux_url = $url;
-	$windows_url = $url;
-	$mac_url = $url;
+	$stableUrl = 'https://github.com/nextcloud-releases/desktop/releases/download/v' . $stableVersion . '/';
+	$stable_linux_url = $stableUrl;
+	$stable_windows_url = $stableUrl;
+	$stable_mac_url = $stableUrl;
+
+	$betaUrl = 'https://github.com/nextcloud-releases/desktop/releases/download/v' . $betaVersion . '/';
+	$beta_linux_url = $betaUrl;
+	$beta_windows_url = $betaUrl;
+	$beta_mac_url = $betaUrl;
 }
 
 if (version_compare($version, '3.1.0') < 0) {
     $windows_suffix = '-setup.exe';
-    $ver = '3.1.3';
+    $stableVersion = '3.1.3';
 } else {
     if ($buildArch === 'i386') {
         $windows_suffix = '-x86.msi';
     } else {
-        $windows_suffix = '-x64.msi';
+        $windows_suffix = '-x86_64.msi';
     }
 }
 
@@ -55,24 +64,47 @@ if (version_compare($version, '3.1.0') < 0) {
  */
 return [
 	'Nextcloud' => [
-		'release' => $rel,
-		'linux' => [
-			'version' => $ver,
-			'versionstring' => $ver_str,
-			'downloadurl' => $linux_url . 'Nextcloud-' . $ver . '-x86_64.AppImage',
-			'web' => 'https://nextcloud.com/install/?pk_campaign=clientupdate#install-clients',
+		'stable' => [
+			'release' => $stableReleaseDate,
+			'linux' => [
+				'version' => $stableVersion,
+				'versionstring' => $stableVersionString,
+				'downloadurl' => $stable_linux_url . 'Nextcloud-' . $stableVersion . '-x64.AppImage',
+				'web' => 'https://nextcloud.com/install/?pk_campaign=clientupdate#install-clients',
+			],
+			'win32' => [
+				'version' => $stableVersion,
+				'versionstring' => $stableVersionString,
+				'downloadurl' => $stable_windows_url . 'Nextcloud-' . $stableVersion . $windows_suffix,
+				'web' => 'https://nextcloud.com/install/?pk_campaign=clientupdate#install-clients',
+			],
+			'macos' => [
+				'version' => $stableVersion,
+				'versionstring' => $stableVersionString,
+				'downloadurl' => $stable_mac_url . 'Nextcloud-' . $stableVersion . '.pkg',
+				'web' => 'https://nextcloud.com/install/?pk_campaign=clientupdate#install-clients',
+			],
 		],
-		'win32' => [
-			'version' => $ver,
-			'versionstring' => $ver_str,
-			'downloadurl' => $windows_url . 'Nextcloud-' . $ver . $windows_suffix,
-			'web' => 'https://nextcloud.com/install/?pk_campaign=clientupdate#install-clients',
-		],
-		'macos' => [
-			'version' => $ver,
-			'versionstring' => $ver_str,
-			'downloadurl' => $mac_url . 'Nextcloud-' . $ver . '.pkg',
-			'web' => 'https://nextcloud.com/install/?pk_campaign=clientupdate#install-clients',
-		],
-	],
+		'beta' => [
+			'release' => $betaReleaseDate,
+			'linux' => [
+				'version' => $betaVersion,
+				'versionstring' => $betaVersionString,
+				'downloadurl' => $beta_linux_url . 'Nextcloud-' . $betaVersion . '-x64.AppImage',
+				'web' => 'https://nextcloud.com/install/?pk_campaign=clientupdate#install-clients',
+			],
+			'win32' => [
+				'version' => $betaVersion,
+				'versionstring' => $betaVersionString,
+				'downloadurl' => $beta_windows_url . 'Nextcloud-' . $betaVersion . $windows_suffix,
+				'web' => 'https://nextcloud.com/install/?pk_campaign=clientupdate#install-clients',
+			],
+			'macos' => [
+				'version' => $betaVersion,
+				'versionstring' => $betaVersionString,
+				'downloadurl' => $beta_mac_url . 'Nextcloud-' . $betaVersion . '.pkg',
+				'web' => 'https://nextcloud.com/install/?pk_campaign=clientupdate#install-clients',
+			],
+		]
+	]
 ];

--- a/index.php
+++ b/index.php
@@ -86,6 +86,7 @@ $currentArch = isset($_GET['currentArch']) ? (string)$_GET['currentArch'] : "x86
 $version = isset($_GET['version']) ? (string)$_GET['version'] : null;
 $isSparkle = isset($_GET['sparkle']) ? true : false;
 $updateSegment = isset($_GET['updatesegment']) ? (int)$_GET['updatesegment'] : -1;
+$channel = isset($_GET['channel']) ? (string)$_GET['channel'] : 'stable';
 
 if($oem === null || $platform === null || $version === null) {
 	die();
@@ -98,6 +99,7 @@ $response = new \ClientUpdateServer\Response(
 	$oem,
 	$platform,
 	$version,
+	$channel,
 	$isSparkle,
 	$updateSegment,
 	$config

--- a/tests/unit/ResponseTest.php
+++ b/tests/unit/ResponseTest.php
@@ -25,31 +25,35 @@ use PHPUnit\Framework\TestCase;
 
 class ResponseTest extends TestCase {
 
-	public function updateDataProvider(): array {
+	public function updateDataProvider(): array
+	{
 		$config = [
 			'nextcloud' => [
-				'release' => '2019-02-24 17:05',
-				'linux' => [
-					'version' => '2.2.2',
-					'versionstring' => 'Nextcloud Client 2.2.2',
-					'web' => 'https://nextcloud.com/install/#install-clients',
+				'stable' => [
+					'release' => '2019-02-24 17:05',
+					'linux' => [
+						'version' => '2.2.2',
+						'versionstring' => 'Nextcloud Client 2.2.2',
+						'web' => 'https://nextcloud.com/install/#install-clients',
+					],
+					'win32' => [
+						'version' => '2.2.2.6192',
+						'versionstring' => 'Nextcloud Client 2.2.2 (build 6192)',
+						'downloadUrl' => 'https://download.nextcloud.com/desktop/stable/ownCloud-2.2.2.6192-setup.exe',
+					],
+					'macos' => [
+						'version' => '2.2.2.3472',
+						'versionstring' => 'Nextcloud Client 2.2.2 (build 3472)',
+						'downloadUrl' => 'https://download.owncloud.com/desktop/stable/ownCloud-2.2.2.3472.pkg.tbz',
+						'signature' => 'MC0CFQDmXR6biDmNVW7TvMh0bfPPTzCvtwIUCzASgpzYdi4lltOnwbFCeQwgDjY=',
+					]
 				],
-				'win32' => [
-					'version' => '2.2.2.6192',
-					'versionstring' => 'Nextcloud Client 2.2.2 (build 6192)',
-					'downloadUrl' => 'https://download.nextcloud.com/desktop/stable/ownCloud-2.2.2.6192-setup.exe',
-				],
-				'macos' => [
-					'version' => '2.2.2.3472',
-					'versionstring' => 'Nextcloud Client 2.2.2 (build 3472)',
-					'downloadUrl' => 'https://download.owncloud.com/desktop/stable/ownCloud-2.2.2.3472.pkg.tbz',
-					'signature' => 'MC0CFQDmXR6biDmNVW7TvMh0bfPPTzCvtwIUCzASgpzYdi4lltOnwbFCeQwgDjY=',
-				],
+				'beta' => []
 			]
 		];
 
 		$configThrottle = $config;
-		$configThrottle['nextcloud']['release'] = (new \DateTime())->sub(new \DateInterval('PT6H'))->format('Y-m-d H:m');
+		$configThrottle['nextcloud']['stable']['release'] = (new \DateTime())->sub(new \DateInterval('PT6H'))->format('Y-m-d H:m');
 
 		return [
 			// Update segment is already allowed
@@ -57,6 +61,7 @@ class ResponseTest extends TestCase {
 				'nextcloud',
 				'win32',
 				'1.9.0',
+				'stable',
 				false,
 				5,
 				$configThrottle,
@@ -69,6 +74,7 @@ class ResponseTest extends TestCase {
 				'nextcloud',
 				'win32',
 				'1.9.0',
+				'stable',
 				false,
 				95,
 				$configThrottle,
@@ -82,6 +88,7 @@ class ResponseTest extends TestCase {
 				'nextcloud',
 				'win32',
 				'1.9.0',
+				'stable',
 				false,
 				-1,
 				$config,
@@ -93,6 +100,7 @@ class ResponseTest extends TestCase {
 				'nextcloud',
 				'win32',
 				'1.9.0',
+				'stable',
 				true,
 				-1,
 				$config,
@@ -104,6 +112,7 @@ class ResponseTest extends TestCase {
 				'nextcloud',
 				'linux',
 				'1.9.0',
+				'stable',
 				false,
 				-1,
 				$config,
@@ -115,6 +124,7 @@ class ResponseTest extends TestCase {
 			'nextcloud',
 				'macos',
 				'1.9.0',
+				'stable',
 				false,
 				-1,
 				$config,
@@ -126,6 +136,7 @@ class ResponseTest extends TestCase {
 				'nextcloud',
 				'macos',
 				'1.9.0',
+				'stable',
 				true,
 				-1,
 				$config,
@@ -147,6 +158,7 @@ class ResponseTest extends TestCase {
 				'randomOem',
 				'macos',
 				'1.9.0',
+				'stable',
 				false,
 				-1,
 				$config,
@@ -156,8 +168,9 @@ class ResponseTest extends TestCase {
 			],
 			[
 				'nextcloud',
-				'ramdomOs',
+				'randomOs',
 				'1.9.0',
+				'stable',
 				false,
 				-1,
 				$config,
@@ -170,6 +183,7 @@ class ResponseTest extends TestCase {
 				'nextcloud',
 				'win32',
 				'2.2.2.6192',
+				'stable',
 				false,
 				-1,
 				$config,
@@ -181,6 +195,7 @@ class ResponseTest extends TestCase {
 				'nextcloud',
 				'win32',
 				'2.2.6192',
+				'stable',
 				true,
 				-1,
 				$config,
@@ -192,6 +207,7 @@ class ResponseTest extends TestCase {
 				'nextcloud',
 				'linux',
 				'2.2.2',
+				'stable',
 				false,
 				-1,
 				$config,
@@ -203,6 +219,7 @@ class ResponseTest extends TestCase {
 				'nextcloud',
 				'macos',
 				'2.2.2.3472',
+				'stable',
 				false,
 				-1,
 				$config,
@@ -214,6 +231,7 @@ class ResponseTest extends TestCase {
 				'nextcloud',
 				'macos',
 				'2.2.2.3472',
+				'stable',
 				true,
 				-1,
 				$config,
@@ -230,6 +248,7 @@ class ResponseTest extends TestCase {
 				'nextcloud',
 				'win32',
 				'2.3',
+				'stable',
 				false,
 				-1,
 				$config,
@@ -241,6 +260,7 @@ class ResponseTest extends TestCase {
 				'nextcloud',
 				'win32',
 				'2.3',
+				'stable',
 				true,
 				-1,
 				$config,
@@ -252,6 +272,7 @@ class ResponseTest extends TestCase {
 				'nextcloud',
 				'linux',
 				'2.3',
+				'stable',
 				false,
 				-1,
 				$config,
@@ -263,6 +284,7 @@ class ResponseTest extends TestCase {
 				'nextcloud',
 				'macos',
 				'2.3',
+				'stable',
 				false,
 				-1,
 				$config,
@@ -274,6 +296,7 @@ class ResponseTest extends TestCase {
 				'nextcloud',
 				'macos',
 				'2.3',
+				'stable',
 				true,
 				-1,
 				$config,
@@ -294,6 +317,7 @@ class ResponseTest extends TestCase {
 	 * @param string $oem
 	 * @param string $platform
 	 * @param string $version
+	 * @param string $channel
 	 * @param bool $isSparkle
 	 * @param int $updateSegment
 	 * @param array $config
@@ -302,12 +326,13 @@ class ResponseTest extends TestCase {
 	public function testBuildResponse(string $oem,
 									  string $platform,
 									  string $version,
+									  string $channel,
 									  bool $isSparkle,
 									  int $updateSegment,
 									  array $config,
 									  string $expected) {
 		$response = $this->getMockBuilder('\ClientUpdateServer\Response')
-			->setConstructorArgs([$oem, $platform, $version, $isSparkle, $updateSegment, $config])
+			->setConstructorArgs([$oem, $platform, $version, $channel, $isSparkle, $updateSegment, $config])
 			->setMethods(['getCurrentTimeStamp'])
 			->getMock();
 		$response


### PR DESCRIPTION
How to test
- run locally via composer start
- curl --request GET --url 'http://localhost:1234/?oem=Nextcloud&version=3.4.0&platform=linux'
- test
  - without channel
  - with channel
  - upgrade from stable to beta version
  - send beta version, shall not offer downgrade, but only next stable

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>