### PR TITLE
Always provide Sparkle update data, fixing no valid update error

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -86,11 +86,11 @@ class Response {
 		$stable = $this->config[$this->oem]['stable'][$this->platform];
 		$beta = $this->config[$this->oem]['beta'][$this->platform];
 
-		if ($this->channel == 'beta' && version_compare($stable['version'], $beta['version']) == -1) {
+		if ($this->channel == 'beta' && (version_compare($stable['version'], $beta['version']) == -1 || ($this->platform === 'macos' && $this->isSparkle === true))) {
 			return $beta;
 		}
 
-		if (version_compare($this->version, $stable['version']) == -1) {
+		if (version_compare($this->version, $stable['version']) == -1 || ($this->platform === 'macos' && $this->isSparkle === true)) {
 			return $stable;
 		}
 

--- a/tests/unit/ResponseTest.php
+++ b/tests/unit/ResponseTest.php
@@ -270,7 +270,7 @@ class ResponseTest extends TestCase {
 <owncloudclient/>
 '
 			],
-			// #16
+			// #16 Except for Sparkle, which always needs to know what the latest version is
 			[
 				'nextcloud',
 				'macos',
@@ -283,7 +283,12 @@ class ResponseTest extends TestCase {
 	<channel>
 		<title>Download Channel</title>
 		<description>Most recent changes with links to updates.</description>
-		<language>en</language></channel>
+		<language>en</language><item>
+					<title>Nextcloud Client 2.2.2 (build 3472)</title>
+					<pubDate>Wed, 13 July 16 21:07:31 +0200</pubDate>
+					<enclosure url="https://download.owncloud.com/desktop/stable/ownCloud-2.2.2.3472.pkg.tbz" sparkle:version="2.2.2.3472" type="application/octet-stream" sparkle:edSignature="MC0CFQDmXR6biDmNVW7TvMh0bfPPTzCvtwIUCzASgpzYdi4lltOnwbFCeQwgDjY=" length="62738920"/>
+					<sparkle:minimumSystemVersion>10.13.0</sparkle:minimumSystemVersion>
+				</item></channel>
 			</rss>'
 			],
 			// #17 No updates if the version is higher
@@ -334,7 +339,7 @@ class ResponseTest extends TestCase {
 <owncloudclient/>
 '
 			],
-			// #21
+			// #21 Again, Sparkle needs to know about the latest version
 			[
 				'nextcloud',
 				'macos',
@@ -347,7 +352,12 @@ class ResponseTest extends TestCase {
 	<channel>
 		<title>Download Channel</title>
 		<description>Most recent changes with links to updates.</description>
-		<language>en</language></channel>
+		<language>en</language><item>
+					<title>Nextcloud Client 2.2.2 (build 3472)</title>
+					<pubDate>Wed, 13 July 16 21:07:31 +0200</pubDate>
+					<enclosure url="https://download.owncloud.com/desktop/stable/ownCloud-2.2.2.3472.pkg.tbz" sparkle:version="2.2.2.3472" type="application/octet-stream" sparkle:edSignature="MC0CFQDmXR6biDmNVW7TvMh0bfPPTzCvtwIUCzASgpzYdi4lltOnwbFCeQwgDjY=" length="62738920"/>
+					<sparkle:minimumSystemVersion>10.13.0</sparkle:minimumSystemVersion>
+				</item></channel>
 			</rss>'
 			],
 		];

--- a/tests/unit/ResponseTest.php
+++ b/tests/unit/ResponseTest.php
@@ -360,7 +360,49 @@ class ResponseTest extends TestCase {
 				</item></channel>
 			</rss>'
 			],
-		];
+            // #22 Sparkle on, always needs to know what the latest version is
+            [
+                'nextcloud',
+                'macos',
+                '2.2.2-rc2',
+                'beta',
+                true,
+                $config,
+                '<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/">
+	<channel>
+		<title>Download Channel</title>
+		<description>Most recent changes with links to updates.</description>
+		<language>en</language><item>
+					<title>Nextcloud Client 2.2.2-rc2</title>
+					<pubDate>Wed, 13 July 16 21:07:31 +0200</pubDate>
+					<enclosure url="https://download.nextcloud.com/desktop/stable/Nextcloud-2.2.2-rc1.pkg.tbz" sparkle:version="2.2.2-rc2" type="application/octet-stream" sparkle:edSignature="MC0CFQDmXR6biDmNVW7TvMh0bfPPTzCvtwIUCzASgpzYdi4lltOnwbFCeQwgDjY=" length="62738920"/>
+					<sparkle:minimumSystemVersion>10.13.0</sparkle:minimumSystemVersion>
+				</item></channel>
+			</rss>'
+		    ],
+            // #23 Sparkle on, always needs to know what the latest version is
+            [
+                'nextcloud',
+                'macos',
+                '2.2.2',
+                'beta',
+                true,
+                $config,
+                '<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/">
+	<channel>
+		<title>Download Channel</title>
+		<description>Most recent changes with links to updates.</description>
+		<language>en</language><item>
+					<title>Nextcloud Client 2.2.2-rc2</title>
+					<pubDate>Wed, 13 July 16 21:07:31 +0200</pubDate>
+					<enclosure url="https://download.nextcloud.com/desktop/stable/Nextcloud-2.2.2-rc1.pkg.tbz" sparkle:version="2.2.2-rc2" type="application/octet-stream" sparkle:edSignature="MC0CFQDmXR6biDmNVW7TvMh0bfPPTzCvtwIUCzASgpzYdi4lltOnwbFCeQwgDjY=" length="62738920"/>
+					<sparkle:minimumSystemVersion>10.13.0</sparkle:minimumSystemVersion>
+				</item></channel>
+			</rss>'
+            ]
+            ];
 	}
 
 	/**


### PR DESCRIPTION
Sparkle always needs data on the latest version, or the update check will provide an error. This PR ensures the latest version data is always provided.

Fixes https://github.com/nextcloud/desktop/issues/4627