### PR TITLE
Skip 3.14.0 for macOS versions under 12

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -100,9 +100,17 @@ class Response {
 
 		// if outdated platform, hand out latest stable-qt5, no daily/beta possible
 		if ($this->checkOldPlatform()) {
-			$stable = $this->config[$this->oem]['stable-qt5'][$this->platform];
-			$beta = null;
-			$daily = null;
+            $stable = $this->config[$this->oem]['stable-qt5'][$this->platform];
+            $beta = null;
+            $daily = null;
+        } else if (version_compare($this->osVersion, '12.0', '<') &&
+                   version_compare($this->version, '3.14.0', '<') &&
+                   version_compare($this->config[$this->oem]['stable'][$this->platform]['version'], '3.14.0', '==')) {
+            // Skip 3.14.0 for macOS < 12 when updating as we have an issue with the system requirement settings
+            // Serve the prior version instead in the meantime (3.13.4)
+            $stable = $this->config[$this->oem]['stable-qt5'][$this->platform];
+            $beta = $this->config[$this->oem]['beta'][$this->platform];
+            $daily = $this->config[$this->oem]['daily'][$this->platform];
 		} else {
 			$stable = $this->config[$this->oem]['stable'][$this->platform];
 			$beta = $this->config[$this->oem]['beta'][$this->platform];


### PR DESCRIPTION
We have an issue with the system requirement settings:

https://help.nextcloud.com/t/nextcloud-client-3-14-0-drops-bigsur/204232

A fix requires merging https://github.com/nextcloud/desktop/pull/7172 and generating a new bugfix release. In the meantime, this should stop the 3.14.0 update being delivered to Big Sur users and breaking their client