### PR TITLE
fix: add missing fileProviderVersionString to beta update info

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -196,6 +196,7 @@ return [
 			'macos' => [
 				'version' => $betaVersionInternal,
 				'versionstring' => $betaVersionString,
+				"fileProviderVersionString" => $betaVersionString,
 				'downloadurl' => $betaUrl . 'Nextcloud-' . $betaVersion . '.pkg',
 				'fileProviderDownloadUrl' => $betaUrl . 'Nextcloud-' . $betaVersion . '-macOS-vfs.pkg',
 				'web' => 'https://nextcloud.com/install',


### PR DESCRIPTION
Resolves nextcloud/desktop#8469