### PR TITLE
fix: revert "chore: release 33.0.3 to stable update channel"

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -37,10 +37,10 @@ $stableQt69VersionFileProviderLength = 373257027;
 //
 // stable
 //
-$stableReleaseDate = '2026-04-27 18:00';
-$stableVersion = '33.0.3';
-$stableVersionSignature = 'wVJdrskFEZbxnxYKoClMGj7jeBS/ewQyvGpm2zaa31LsawMT8Q13l0MfuLiZNtOpgjtCVC8MLTm1+VOIi08UBw==';
-$stableVersionLength = 383482172;
+$stableReleaseDate = '2026-03-31 18:00';
+$stableVersion = '33.0.2';
+$stableVersionSignature = 'eOhMIk4G2sfQEYJguTCDL9Kab+xJPei32NHW8s9Lmcd6eg1gUva1+c+gUBK32mCT5xzZMNtUVEzjXs1eukHGAQ==';
+$stableVersionLength = 383154984;
 
 //
 // enterprise 


### PR DESCRIPTION
Reverts commit https://github.com/nextcloud/client_updater_server/commit/b677c03e31abd236bb06b1e722826334330ad08f because of https://github.com/nextcloud/desktop/issues/9924.