### PR TITLE
feature: Enterprise clients now receive stable patch versions

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -115,7 +115,12 @@ class Response {
 		    if (version_compare($this->version, $enterprise['version']) === -1 || $isMacOs) {
 		        return $enterprise;
 		    }
-		    return []; // do not fall back to stable in case there is no enterprise update
+		    if (version_compare($this->version, $enterprise['version']) === 1
+		        && version_compare($this->version, $stable['version']) === -1
+		        && $this->hasSameMajorVersion($this->version, $stable['version'])) {
+		        return $stable;
+		    }
+		    return []; // Otherwise do not fall back to stable when there is no enterprise update
 		}
 
 		if (version_compare($this->version, $stable['version']) == -1 || $isMacOs) {
@@ -123,6 +128,10 @@ class Response {
 		}
 
 		return [];
+	}
+
+	private function hasSameMajorVersion(string $currentVersion, string $updateVersion): bool {
+		return explode('.', $currentVersion, 2)[0] === explode('.', $updateVersion, 2)[0];
 	}
 
 	private function getLegacyChannel(): ?string {

--- a/src/Response.php
+++ b/src/Response.php
@@ -112,13 +112,13 @@ class Response {
 		}
 
 		if ($this->channel === 'enterprise' && isset($enterprise)) {
-		    if (version_compare($this->version, $enterprise['version']) === -1 || $isMacOs) {
-		        return $enterprise;
-		    }
 		    if (version_compare($this->version, $enterprise['version']) === 1
 		        && version_compare($this->version, $stable['version']) === -1
 		        && $this->hasSameMajorVersion($this->version, $stable['version'])) {
 		        return $stable;
+		    }
+		    if (version_compare($this->version, $enterprise['version']) === -1 || $isMacOs) {
+		        return $enterprise;
 		    }
 		    return []; // Otherwise do not fall back to stable when there is no enterprise update
 		}

--- a/tests/unit/ResponseTest.php
+++ b/tests/unit/ResponseTest.php
@@ -140,6 +140,18 @@ class ResponseTest extends TestCase {
 		$configThrottle = $config;
 		$configThrottle['nextcloud']['stable']['release'] = (new \DateTime())->sub(new \DateInterval('PT6H'))->format('Y-m-d H:m');
 
+		$configEnterprisePatchFallback = $config;
+		$configEnterprisePatchFallback['nextcloud']['enterprise']['win32'] = [
+			'version' => '4.0.10',
+			'versionstring' => 'Nextcloud Client 4.0.10',
+			'downloadurl' => 'https://download.nextcloud.com/desktop/stable/Nextcloud-4.0.10-setup.exe',
+		];
+		$configEnterprisePatchFallback['nextcloud']['stable']['win32'] = [
+			'version' => '33.0.5',
+			'versionstring' => 'Nextcloud Client 33.0.5',
+			'downloadurl' => 'https://download.nextcloud.com/desktop/stable/Nextcloud-33.0.5-setup.exe',
+		];
+
 		return [
 			// #0 Update segment is already allowed
 			[
@@ -990,7 +1002,55 @@ class ResponseTest extends TestCase {
 		</item>
 	</channel>
 </rss>'
-			],				
+			],
+			// #43 Manually upgraded enterprise client gets stable patches from its current major version
+			[
+				'nextcloud',
+				'win32',
+				'33.0.2',
+				'',
+				'11',
+				'10.0.26080',
+				'enterprise',
+				false,
+				false,
+				$configEnterprisePatchFallback,
+				'<?xml version="1.0"?>
+<owncloudclient><version>33.0.5</version><versionstring>Nextcloud Client 33.0.5</versionstring><downloadurl>https://download.nextcloud.com/desktop/stable/Nextcloud-33.0.5-setup.exe</downloadurl></owncloudclient>
+'
+			],
+			// #44 Enterprise fallback does not move a manually upgraded client to another major version
+			[
+				'nextcloud',
+				'win32',
+				'32.0.2',
+				'',
+				'11',
+				'10.0.26080',
+				'enterprise',
+				false,
+				false,
+				$configEnterprisePatchFallback,
+				'<?xml version="1.0"?>
+<owncloudclient/>
+'
+			],
+			// #45 Enterprise fallback does not offer an update when the stable patch is already installed
+			[
+				'nextcloud',
+				'win32',
+				'33.0.5',
+				'',
+				'11',
+				'10.0.26080',
+				'enterprise',
+				false,
+				false,
+				$configEnterprisePatchFallback,
+				'<?xml version="1.0"?>
+<owncloudclient/>
+'
+			],
         ];
 	}
 

--- a/tests/unit/ResponseTest.php
+++ b/tests/unit/ResponseTest.php
@@ -151,6 +151,22 @@ class ResponseTest extends TestCase {
 			'versionstring' => 'Nextcloud Client 33.0.5',
 			'downloadurl' => 'https://download.nextcloud.com/desktop/stable/Nextcloud-33.0.5-setup.exe',
 		];
+		$configEnterprisePatchFallback['nextcloud']['enterprise']['macos'] = array_merge(
+			$configEnterprisePatchFallback['nextcloud']['enterprise']['macos'],
+			[
+				'version' => '4.0.10',
+				'versionstring' => 'Nextcloud Client 4.0.10',
+			]
+		);
+		$configEnterprisePatchFallback['nextcloud']['stable']['macos'] = array_merge(
+			$configEnterprisePatchFallback['nextcloud']['stable']['macos'],
+			[
+				'version' => '33.0.5',
+				'versionstring' => 'Nextcloud Client 33.0.5',
+				'downloadurl' => 'https://download.nextcloud.com/desktop/stable/Nextcloud-33.0.5.pkg',
+				'sparkleDownloadUrl' => 'https://download.nextcloud.com/desktop/stable/Nextcloud-33.0.5.pkg.tbz',
+			]
+		);
 
 		return [
 			// #0 Update segment is already allowed
@@ -1035,7 +1051,41 @@ class ResponseTest extends TestCase {
 <owncloudclient/>
 '
 			],
-			// #45 Enterprise fallback does not offer an update when the stable patch is already installed
+			// #45 Manually upgraded macOS enterprise client gets stable patches via Sparkle
+			[
+				'nextcloud',
+				'macos',
+				'33.0.2',
+				'',
+				'14.0',
+				'22.00.00',
+				'enterprise',
+				true,
+				false,
+				$configEnterprisePatchFallback,
+				'<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/">
+	<channel>
+		<title>Download Channel</title>
+		<description>Most recent changes with links to updates.</description>
+		<language>en</language>
+		<item>
+			<title>Nextcloud Client 33.0.5</title>
+			<pubDate>Wed, 13 July 16 21:07:31 +0200</pubDate>
+			<enclosure url="https://download.nextcloud.com/desktop/stable/Nextcloud-33.0.5.pkg.tbz" sparkle:version="33.0.5" type="application/octet-stream" sparkle:installationType="package" sparkle:edSignature="MC0CFQDmXR6biDmNVW7TvMh0bfPPTzCvtwIUCzASgpzYdi4lltOnwbFCeQwgDjY=" length="62738920"/>
+			<sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
+			<sparkle:informationalUpdate>
+				<sparkle:version>33.0.0</sparkle:version>
+				<sparkle:version>33.0.0.0</sparkle:version>
+				<sparkle:version>33.0.1</sparkle:version>
+				<sparkle:version>33.0.1.0</sparkle:version>
+			</sparkle:informationalUpdate>
+			<link>https://download.nextcloud.com/desktop/stable/Nextcloud-33.0.5.pkg</link>
+		</item>
+	</channel>
+</rss>'
+			],
+			// #46 Enterprise fallback does not offer an update when the stable patch is already installed
 			[
 				'nextcloud',
 				'win32',


### PR DESCRIPTION
- They were manually upgraded beyond the enterprise release.
- Stable is newer than the installed version.
- Stable remains within the installed major version. Added regression coverage for 4.0.10 -> 33.0.2 -> 33.0.5, cross-major rejection, and already-current clients